### PR TITLE
Fixed modal backdrop fade issue

### DIFF
--- a/index.html
+++ b/index.html
@@ -57,9 +57,9 @@
             <button type="button" class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#exampleModal">
             Launch demo modal
             </button> -->
-
+        </header>
             <!-- Modal -->
-            <div class="modal top fade position-fixed" id="exampleModal" tabindex="-1" aria-labelledby="exampleModalLabel" aria-hidden="true" data-bs-keyboard="true">
+            <div class="modal top fade position-fixed" id="exampleModal" tabindex="10" aria-labelledby="exampleModalLabel" aria-hidden="true" data-bs-keyboard="true">
                 <div class="modal-dialog modal-lg  modal-dialog-centered">
                     <div class="modal-content">
                         <div class="modal-header" style="background-color: #EFFFF4;">
@@ -83,8 +83,6 @@
                     </div>
                 </div>
             </div>
-
-        </header>
         <content class="d-flex flex-row-reverse justify-content-between" style="gap: 40px; margin: 40px 100px 10px 100px;">
             <div class="location mt-5" style="width:25%;">
                 <img src="icons/loc.svg">

--- a/style.css
+++ b/style.css
@@ -104,5 +104,5 @@ svg{
     cursor: pointer;
 }
 .modal-backdrop{
-    z-index: 0;
+    z-index: 20;
 }


### PR DESCRIPTION
Closes #1

## Description

Moved the modal div out of header tag, changed `tabindex` value from -1 to 10 and z-index of `modal-backdrop` class to 20.

## Is this a breaking change?

No